### PR TITLE
Update csvstats.lua

### DIFF
--- a/classes/csvstats.lua
+++ b/classes/csvstats.lua
@@ -1054,7 +1054,7 @@ function CSVStatReader:read_attachments(parent_tweak_data)
 							
 							--Reload Multiplier
 							local reload_mul
-							local _reload_mul = raw_csv_values[STAT_INDICES.reload_internal]
+							local _reload_mul = raw_csv_values[STAT_INDICES.reload]
 							if not_empty(_reload_mul) then 
 								--pre-converted
 								reload_mul = tonumber(_reload_mul)


### PR DESCRIPTION
due to a typo in the stat indices, csvstatreader was not correctly ingesting multipliers on reload in the attachments csv. along with stat fixes to attachments this resolves the issue with speedpull mags not modifying reload speed.